### PR TITLE
proper parsing for independent sources

### DIFF
--- a/InSpice/Probe/WaveForm.py
+++ b/InSpice/Probe/WaveForm.py
@@ -177,7 +177,7 @@ class WaveForm(UnitValues):
 
     def __repr__(self):
         _ = super().__str__()
-        return '{self.__class__.__name__} {self._name} {_}'
+        return f'{self.__class__.__name__} {self._name} {_}'
 
     ##############################################
 

--- a/InSpice/Spice/BasicElement.py
+++ b/InSpice/Spice/BasicElement.py
@@ -128,6 +128,7 @@ from .ElementParameter import (
     InitialStatePositionalParameter,
     IntKeyParameter,
     ModelPositionalParameter,
+    FloatKeywordPositionalParameter
 )
 from . import Library
 from .StringTools import join_list, join_dict
@@ -805,8 +806,9 @@ class VoltageSource(DipoleElement):
     ALIAS = 'V'
     PREFIX = 'V'
 
-    dc_value = ExpressionPositionalParameter(position=0, key_parameter=False)
-    ac_value = FloatKeyParameter("ac", separator=" ", unit=U_V)
+    dc_value = FloatKeywordPositionalParameter("DC", position=0, unit=U_V)
+    ac_value = FloatKeywordPositionalParameter("AC", position=1, unit=U_V)
+    tran_value = ExpressionPositionalParameter(position=2)
 
 ####################################################################################################
 
@@ -832,8 +834,9 @@ class CurrentSource(DipoleElement):
     ALIAS = 'I'
     PREFIX = 'I'
 
-    dc_value = ExpressionPositionalParameter(position=0, key_parameter=False)
-    ac_value = FloatKeyParameter("ac", separator=" ", unit=U_A)
+    dc_value = FloatKeywordPositionalParameter("DC", position=0, unit=U_A)
+    ac_value = FloatKeywordPositionalParameter("AC", position=1, unit=U_A)
+    tran_value = ExpressionPositionalParameter(position=2)
 
 ####################################################################################################
 

--- a/InSpice/Spice/BasicElement.py
+++ b/InSpice/Spice/BasicElement.py
@@ -798,14 +798,15 @@ class VoltageSource(DipoleElement):
     Attributes:
 
       :attr:`dc_value`
+      :attr:`ac_value`
 
     """
 
     ALIAS = 'V'
     PREFIX = 'V'
 
-    # Fixme: ngspice manual doesn't describe well the syntax
-    dc_value = FloatPositionalParameter(position=0, key_parameter=False, unit=U_V)
+    dc_value = ExpressionPositionalParameter(position=0, key_parameter=False)
+    ac_value = FloatKeyParameter("ac", separator=" ", unit=U_V)
 
 ####################################################################################################
 
@@ -824,14 +825,15 @@ class CurrentSource(DipoleElement):
     Attributes:
 
       :attr:`dc_value`
+      :attr:`ac_value`
 
     """
 
     ALIAS = 'I'
     PREFIX = 'I'
 
-    # Fixme: ngspice manual doesn't describe well the syntax
-    dc_value = FloatPositionalParameter(position=0, key_parameter=False, unit=U_A)
+    dc_value = ExpressionPositionalParameter(position=0, key_parameter=False)
+    ac_value = FloatKeyParameter("ac", separator=" ", unit=U_A)
 
 ####################################################################################################
 

--- a/InSpice/Spice/ElementParameter.py
+++ b/InSpice/Spice/ElementParameter.py
@@ -222,6 +222,45 @@ class ModelPositionalParameter(PositionalElementParameter):
 
 ####################################################################################################
 
+class KeywordPositionalElementParameter(PositionalElementParameter):
+    """
+    This class implements a positional element parameter with a keyword.
+
+    Public Attributes:
+
+        :attr:`keyword`
+            The keyword associated with the parameter, which is prepended to the parameter's value
+    """
+
+    def __init__(self, keyword, position, **kwargs):
+        super().__init__(position)
+        self._keyword = keyword
+    
+    def to_str(self, instance):
+        return f"{self._keyword} {super().to_str(instance)}"
+
+####################################################################################################
+
+class FloatKeywordPositionalParameter(KeywordPositionalElementParameter):
+
+    """This class implements a float positional parameter with a keyword."""
+
+    ##############################################
+
+    def __init__(self, keyword, position, unit=None, **kwargs):
+        super().__init__(keyword, position, **kwargs)
+        self._unit = unit
+
+    ##############################################
+
+    def validate(self, value):
+        if isinstance(value, Unit):
+            return value
+        else:
+            return Unit(value)
+
+####################################################################################################
+
 class FlagParameter(ParameterDescriptor):
 
     """This class implements a flag parameter.

--- a/InSpice/Spice/ElementParameter.py
+++ b/InSpice/Spice/ElementParameter.py
@@ -267,9 +267,10 @@ class KeyValueParameter(ParameterDescriptor):
 
     ##############################################
 
-    def __init__(self, spice_name, default=None):
+    def __init__(self, spice_name, default=None, separator='='):
         super().__init__(default)
         self.spice_name = spice_name
+        self.separator = separator
 
     ##############################################
 
@@ -281,7 +282,7 @@ class KeyValueParameter(ParameterDescriptor):
     def to_str(self, instance):
         if bool(self):
             _ = self.str_value(instance)
-            return f'{self.spice_name}={_}'
+            return f'{self.spice_name}{self.separator}{_}'
         else:
             return ''
 


### PR DESCRIPTION
The ngspice syntax for voltage sources is very... flexible.

```
VXXXXXXX N+ N- <<DC> DC/TRAN VALUE> <AC <ACMAG <ACPHASE>>>
```

Here DC is an optional keyword followed by the value used in DC and transient simulations, which can be a function such as SIN or PULSE. Optionally followed by the AC keyword and then either just a magnitude or a magnitude and phase, but 99% of the time just `AC 1`

The examples are illustrative:

```
VCC 10 0 DC 6
VIN 13 2 0.001 AC 1 SIN(0 1 1MEG)
ISRC 23 21 AC 0.333 45.0 SFFM(0 1 10K 5 1K)
```

Except WHAT IS THAT they supply both a DC number without a keyword as well as a function at the end which the grammar doesn't describe as an option at all but which is very much supported.

Fun fact, if you supply both a DC value and a transient value, the DC value will be used in most DC simulations except the initial condition for a transient simulation where it'll use the T=0 value.

So now the question is how the ***** do you express that neatly in Python? Well you don't I guess.

My simplification of the above is that it rarely makes sense to express a DC operating point that is different from the t0 transient value, and the DC keyword is optional. So I've left the dc/tran value as a positional argument, but made it an expression so it can contain a function.

Note that validation doesn't seem fully implemented, nothing seems to ever call `validate` on these parameters.

For AC the keyword is mandatory, but there is currently no parameter syntax for that. It definitely works to just write AC= since most punctuation is pretty much whitespace to a spice parser, but for adherence to the manual I've introduced a separator argument such that we can make AC a key parameter with space as a separator.

This does probably not allow the phase to be expressed which is not ideal. Ideally you'd just pass a complex number and it'd get printed correctly.

For full correctness we'd have to implement some type of "keyword parameter" that behaves as an optional positional parameter so that DISTOF[12] can be added as well. And probably correct printing of complex numbers. And ideally some symbolic representation of the simulation functions.

This PR at least unlocks 90% of the functionality of the independent sources in common usage.