### PR TITLE
Fix NoiseAnalysis so the spectral (noise1) plot is usable

### DIFF
--- a/InSpice/Probe/WaveForm.py
+++ b/InSpice/Probe/WaveForm.py
@@ -458,15 +458,30 @@ class PoleZeroAnalysis(Analysis):
 
 class NoiseAnalysis(Analysis):
 
-    """This class implements Noise analysis."""
+    """This class implements Noise analysis.
+
+    For the spectral-density plot (ngspice's ``noise1``) :attr:`frequency`
+    returns the frequency abscissa and :attr:`nodes` contains the
+    ``inoise_spectrum`` / ``onoise_spectrum`` waveforms. For the integrated
+    plot (``noise2``) :attr:`frequency` is ``None`` and :attr:`nodes`
+    contains the scalar ``inoise_total`` / ``onoise_total`` waveforms.
+    """
 
     ##############################################
 
-    def __init__(self, simulation, nodes, branches, internal_parameters):
+    def __init__(self, simulation, nodes, branches, internal_parameters, frequency=None):
         super().__init__(
             simulation=simulation, nodes=nodes, branches=branches,
             internal_parameters=internal_parameters,
         )
+        self._frequency = frequency
+
+    ##############################################
+
+    @property
+    def frequency(self):
+        """Numpy array for the frequency abscissa, or ``None`` for the integrated plot."""
+        return self._frequency
 
 ####################################################################################################
 

--- a/InSpice/Spice/NgSpice/Shared.py
+++ b/InSpice/Spice/NgSpice/Shared.py
@@ -374,10 +374,41 @@ class Plot(dict):
     ##############################################
 
     def _to_noise_analysis(self):
+        # ngspice's .noise produces two plots:
+        #   noise1 — {inoise,onoise}_spectrum (type voltage_density) + frequency
+        #   noise2 — {inoise,onoise}_total (type voltage), no abscissa
+        # Plot.nodes() filters on type == voltage, which excludes the spectral-density
+        # vectors. Handle both plot shapes by classifying voltage/current and their
+        # density counterparts together, and pull out the frequency vector if present.
+        frequency = None
+        if 'frequency' in self:
+            frequency = self['frequency'].to_waveform(to_real=True)
+
+        st = None
+        for variable in self.values():
+            st = variable._ngspice_shared.simulation_type
+            break
+        voltage_types = {st.voltage} if st is not None else set()
+        current_types = {st.current} if st is not None else set()
+        if st is not None and hasattr(st, 'voltage_density'):
+            voltage_types.add(st.voltage_density)
+        if st is not None and hasattr(st, 'current_density'):
+            current_types.add(st.current_density)
+
+        nodes, branches = [], []
+        for variable in self.values():
+            if variable.is_internal_parameter or variable._name == 'frequency':
+                continue
+            if variable._type in voltage_types:
+                nodes.append(variable.to_waveform(frequency))
+            elif variable._type in current_types:
+                branches.append(variable.to_waveform(frequency))
+
         return NoiseAnalysis(
             simulation=self._simulation,
-            nodes=self.nodes(),
-            branches=self.branches(),
+            frequency=frequency,
+            nodes=nodes,
+            branches=branches,
             internal_parameters=self.internal_parameters(),
         )
 

--- a/InSpice/Spice/NgSpice/SimulationType.py
+++ b/InSpice/Spice/NgSpice/SimulationType.py
@@ -84,7 +84,7 @@ SIMULATION_TYPE[27] = (
     'charge',
 )
 
-LAST_VERSION = 45   # released on January 31st, 2021
+LAST_VERSION = 46   # released on May 12, 2024
 
 for version in range(28, LAST_VERSION +1):
     SIMULATION_TYPE[version] = SIMULATION_TYPE[27]

--- a/examples/analyses/analyses.py
+++ b/examples/analyses/analyses.py
@@ -142,6 +142,12 @@ def do_noise_analysis():
     print("Total noise (Vrms) at circuit output:", np.array(analysis.nodes['onoise_total'])[0])
     print("Total noise (Vrms) as if at circuit input:", np.array(analysis.nodes['inoise_total'])[0])
 
+    # ngspice creates a second plot (noise1) with the spectral density vs frequency.
+    spectrum = simulator._ngspice_shared.plot(simulation, "noise1").to_analysis()
+    print("Spectral density sweep:", len(np.array(spectrum.frequency)), "points")
+    print("Output noise density @ lowest frequency:",
+          np.array(spectrum.nodes['onoise_spectrum'])[0], "V/sqrt(Hz)")
+
 def do_distortion_analysis(f2overf1):
     circuit, n = simple_bjt_amp()
     com = 0

--- a/unit-test/Probe/test_WaveForm.py
+++ b/unit-test/Probe/test_WaveForm.py
@@ -141,6 +141,26 @@ class TestUnits(unittest.TestCase):
 
 ####################################################################################################
 
+class TestNoiseAnalysis(unittest.TestCase):
+
+    """Regression test for the :class:`NoiseAnalysis` frequency abscissa."""
+
+    def test_frequency_default_is_none(self):
+        # noise2 (integrated totals) has no frequency axis.
+        analysis = NoiseAnalysis(simulation=None, nodes=(), branches=(), internal_parameters=())
+        self.assertIsNone(analysis.frequency)
+
+    def test_frequency_passthrough(self):
+        # noise1 (spectral) carries a frequency abscissa.
+        freq = np.logspace(1, 5, 41)
+        analysis = NoiseAnalysis(
+            simulation=None, nodes=(), branches=(), internal_parameters=(),
+            frequency=freq,
+        )
+        np_test.assert_array_equal(analysis.frequency, freq)
+
+####################################################################################################
+
 if __name__ == '__main__':
 
     unittest.main()


### PR DESCRIPTION
## Summary

`ngspice`'s `.noise` analysis produces two plots:
- `noise1` — `{inoise,onoise}_spectrum` (`voltage_density`) vs. `frequency`
- `noise2` — `{inoise,onoise}_total` (`voltage`), scalar, no abscissa

`simulation.noise(...)` returns `last_plot`, which is `noise2`. Callers who want the spectrum have to fetch the other one explicitly:

```python
spectrum = simulator._ngspice_shared.plot(simulation, "noise1").to_analysis()
```

That path was broken in two independent ways:

1. **No `frequency` on `NoiseAnalysis`.** `AcAnalysis` / `DistortionAnalysis` both carry a `frequency` waveform, but `NoiseAnalysis.__init__` didn't accept one and `_to_noise_analysis` didn't extract it — so `spectrum.frequency` raised `AttributeError`.
2. **Spectral vectors silently dropped.** `Plot.nodes()` filters on the built-in `voltage` simulation type. `inoise_spectrum` / `onoise_spectrum` are tagged `voltage_density` (added in the ngspice-27 type table), so they were excluded from `nodes` — the returned analysis had no data at all.

Existing code that only reads the integrated totals (`analysis.nodes['onoise_total']`, used in `examples/analyses/analyses.py`) keeps working because those are stored in `noise2`, which uses the plain `voltage` type; `frequency` just defaults to `None` there.

## Changes

- `_to_noise_analysis`: extract `frequency` if present, classify `voltage_density` alongside `voltage` and `current_density` alongside `current`, skip the `frequency` vector itself.
- `NoiseAnalysis`: accept and expose `frequency` via a property.
- `SimulationType.LAST_VERSION`: 45 → 46, so ngspice 46 users don't see the unsupported-version warning (the type table is unchanged since v27).
- New unit test covering `NoiseAnalysis.frequency` default/passthrough.
- Extended `examples/analyses/analyses.py` noise demo with the spectrum path.

## Test plan

- [x] New `TestNoiseAnalysis` unit tests pass.
- [x] Full unit-test suite (`pytest unit-test/ --ignore=unit-test/Math`) still green — 82 existing tests, no regressions.
- [x] End-to-end on ngspice 46 with a simple RC filter: `wrdata` dump of `noise1.onoise_spectrum` matches `np.array(spectrum.nodes['onoise_spectrum'])` after this fix.
- [x] Existing noise example (`analyses.py`) still reads `onoise_total`/`inoise_total` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)