### PR TITLE
Split PyPI publish into separate jobs for InSpice and vacask-bin

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -61,25 +61,15 @@ jobs:
           name: vacask-bin-dists
           path: dist/
 
-  pypi-publish:
+  pypi-publish-inspice:
     runs-on: ubuntu-latest
     needs:
       - release-build
-      - vacask-bin-build
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
-
-    # Dedicated environments with protections for publishing are strongly recommended.
-    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
     environment:
       name: pypi
-      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-      # url: https://pypi.org/p/YOURPROJECT
-      #
-      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
-      # ALTERNATIVE: exactly, uncomment the following line instead:
-      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+      url: https://pypi.org/p/inspice
 
     steps:
       - name: Retrieve release distributions
@@ -88,13 +78,30 @@ jobs:
           name: release-dists
           path: dist/
 
+      - name: Publish InSpice to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+
+  pypi-publish-vacask-bin:
+    runs-on: ubuntu-latest
+    needs:
+      - vacask-bin-build
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/vacask-bin
+
+    steps:
       - name: Retrieve vacask-bin distributions
         uses: actions/download-artifact@v4
         with:
           name: vacask-bin-dists
           path: dist/
 
-      - name: Publish release distributions to PyPI
+      - name: Publish vacask-bin to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -69,7 +69,7 @@ jobs:
       id-token: write
     environment:
       name: pypi
-      url: https://pypi.org/p/inspice
+      url: https://pypi.org/p/InSpice
 
     steps:
       - name: Retrieve release distributions


### PR DESCRIPTION
## Summary
- Split the single `pypi-publish` job into two independent jobs: `pypi-publish-inspice` and `pypi-publish-vacask-bin`
- Each job gets its own OIDC token exchange, required because trusted publishing tokens are project-scoped
- The two publish jobs now run in parallel since they don't depend on each other

## Test plan
- [ ] Create a release and verify both InSpice and vacask-bin publish successfully to PyPI
- [ ] Verify the trusted publisher for vacask-bin is configured with environment name `pypi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)