### PR TITLE
Fix VACASK error detection for failed/aborted analyses

### DIFF
--- a/InSpice/Spice/Vacask/Server.py
+++ b/InSpice/Spice/Vacask/Server.py
@@ -102,7 +102,8 @@ class VacaskServer:
         if err_output:
             self._logger.debug(os.linesep + err_output)
 
-        if 'Error' in output or 'error' in err_output or 'failed' in output.lower() or 'aborted' in output.lower():
+        combined = (output + err_output).lower()
+        if any(kw in combined for kw in ('error', 'failed', 'aborted')):
             raise NameError("Errors found by VACASK:\n" + output + err_output)
 
     ##############################################

--- a/InSpice/Spice/Vacask/Server.py
+++ b/InSpice/Spice/Vacask/Server.py
@@ -102,7 +102,7 @@ class VacaskServer:
         if err_output:
             self._logger.debug(os.linesep + err_output)
 
-        if 'Error' in output or 'error' in err_output:
+        if 'Error' in output or 'error' in err_output or 'failed' in output.lower() or 'aborted' in output.lower():
             raise NameError("Errors found by VACASK:\n" + output + err_output)
 
     ##############################################


### PR DESCRIPTION
## Summary
- VACASK can exit with code 0 even when an analysis fails (e.g. matrix factorization failure, homotopy failure). The `_parse_stdout` method only checked for the word "Error" (case-sensitive in stdout, lowercase in stderr), missing diagnostics like "Factorization failed" and "Analysis 'op1' aborted".
- Normalize error detection: combine stdout+stderr, check case-insensitively for "error", "failed", and "aborted".
- Without this fix, failed simulations silently produce no raw file, and the user gets a confusing "Expected raw file not found" error instead of the actual simulator diagnostic.

## Test plan
- [x] Verified a working simulation (RC circuit operating point) still succeeds
- [x] Verified a broken circuit (two voltage sources in parallel) now raises with the full VACASK diagnostic message