### PR TITLE
Fix & extend transient-source codegen for the VACASK target

### DIFF
--- a/InSpice/Spice/Element.py
+++ b/InSpice/Spice/Element.py
@@ -642,6 +642,22 @@ class Element(metaclass=ElementParameterMetaClass):
         if module is None:
             return f"// Unsupported element: {self.name}"
 
+        # A generic VoltageSource/CurrentSource carries any transient waveform in
+        # tran_value as a raw SPICE string (an ExpressionPositionalParameter with
+        # no spectre_name). format_spectre_parameters only emits params whose
+        # spectre_name is not None, so tran_value would be silently dropped here,
+        # leaving the source as a flat dc=0 on the vacask path. Fail loudly and
+        # point users to the dedicated structural source classes instead.
+        tran_value = getattr(self, 'tran_value', None)
+        if tran_value is not None and str(tran_value).strip():
+            raise NotImplementedError(
+                f"Element {self.name} carries a raw SPICE transient ({tran_value!r}) "
+                "that cannot be translated to the Spectre/VACASK form and would be "
+                "silently dropped (yielding a flat DC source). Use a dedicated "
+                "structural source class instead (e.g. SinusoidalVoltageSource, "
+                "PulseVoltageSource, ExponentialVoltageSource)."
+            )
+
         name = self.name.lower()
         nodes = ' '.join(str(n) for n in self.node_names)
         params = self.format_spectre_parameters()

--- a/InSpice/Spice/HighLevelElement.py
+++ b/InSpice/Spice/HighLevelElement.py
@@ -304,7 +304,12 @@ class PulseMixin(SourceMixinAbc):
         delay = self.delay_time
         if delay is not None and float(delay) != 0:
             parts.append(f"delay={format_spectre_value(delay)}")
-        parts.append(f"rise={format_spectre_value(self.rise_time)}")
+        # vacask rejects rise <= 0 and defaults rise to 1n when omitted. InSpice's
+        # rise_time defaults to 0, so only emit rise= when it is > 0 and otherwise
+        # let vacask fall back to its 1n default. Caveat: a true zero-rise edge is
+        # not representable in vacask. (fall/width/period of 0 are valid in vacask.)
+        if self.rise_time is not None and float(self.rise_time) > 0:
+            parts.append(f"rise={format_spectre_value(self.rise_time)}")
         parts.append(f"fall={format_spectre_value(self.fall_time)}")
         parts.append(f"width={format_spectre_value(self.pulse_width)}")
         parts.append(f"period={format_spectre_value(self.period)}")
@@ -383,16 +388,37 @@ class ExponentialMixin(SourceMixinAbc):
 
     def format_spectre_parameters(self):
         from .Spectre import format_spectre_value
+        # vacask's exp waveform uses t_fall_start = delay + td2, i.e. td2 is the
+        # *duration* of the rise measured from delay (devvisrc.cpp sourceCompute),
+        # whereas SPICE's TD2 (fall_delay_time) is absolute from t=0. vacask also
+        # requires td2 > 0 and divides the rising exponential by tau1. Map the
+        # SPICE parameters to vacask's semantics, and fail loudly rather than emit
+        # a netlist vacask rejects opaquely (or silently falls back to dc on).
+        if self.fall_delay_time is None:
+            raise ValueError(
+                "VACASK exp source requires an explicit fall_delay_time: vacask has "
+                "no default for td2 and rejects td2 <= 0."
+            )
+        if self.rise_time_constant is None:
+            raise ValueError(
+                "VACASK exp source requires an explicit rise_time_constant: vacask "
+                "divides the rising exponential by tau1."
+            )
+        delay = float(self.rise_delay_time) if self.rise_delay_time is not None else 0.0
+        td2 = float(self.fall_delay_time) - delay
+        if td2 <= 0:
+            raise ValueError(
+                "VACASK exp source requires fall_delay_time later than rise_delay_time: "
+                "td2 = fall_delay_time - rise_delay_time must be > 0."
+            )
         parts = []
         parts.append('type="exp"')
         parts.append(f"val0={format_spectre_value(self.initial_value)}")
         parts.append(f"val1={format_spectre_value(self.pulsed_value)}")
-        if self.rise_delay_time is not None:
+        if delay != 0:
             parts.append(f"delay={format_spectre_value(self.rise_delay_time)}")
-        if self.rise_time_constant is not None:
-            parts.append(f"tau1={format_spectre_value(self.rise_time_constant)}")
-        if self.fall_delay_time is not None:
-            parts.append(f"td2={format_spectre_value(self.fall_delay_time)}")
+        parts.append(f"tau1={format_spectre_value(self.rise_time_constant)}")
+        parts.append(f"td2={format_spectre_value(td2)}")
         if self.fall_time_constant is not None:
             parts.append(f"tau2={format_spectre_value(self.fall_time_constant)}")
         return ' '.join(parts)
@@ -458,15 +484,13 @@ class PieceWiseLinearMixin(SourceMixinAbc):
         return _
 
     def format_spectre_parameters(self):
-        from .Spectre import format_spectre_value
-        parts = []
-        parts.append('type="pwl"')
-        values = self.values
-        pwl_pairs = []
-        for i in range(0, len(values), 2):
-            pwl_pairs.append(f"{format_spectre_value(values[i])}, {format_spectre_value(values[i+1])}")
-        parts.append(f"wave=[{'; '.join(pwl_pairs)}]")
-        return ' '.join(parts)
+        # vacask's sourceCompute has no Pwl branch (devvisrc.cpp): type="pwl" sets
+        # up without error but computes an uninitialised value, so PWL is unusable
+        # end-to-end. Fail loudly rather than emit a silently-broken netlist.
+        raise NotImplementedError(
+            "PWL transient sources are not yet supported by VACASK "
+            "(no Pwl branch in the source compute path)"
+        )
 
 ####################################################################################################
 
@@ -519,7 +543,18 @@ class SingleFrequencyFMMixin(SourceMixinAbc):
                 ')')
 
     def format_spectre_parameters(self):
-        raise NotImplementedError("SFFM sources are not supported in Spectre/VACASK output")
+        from .Spectre import format_spectre_value
+        # SPICE SFFM(VO VA FC MDI FS) matches vacask's type="fm" exactly with all
+        # phase params 0: V(t) = sinedc + ampl*sin(2*pi*freq*t + modindex*sin(2*pi*modfreq*t))
+        # (devvisrc.cpp sourceCompute Fm branch).
+        parts = []
+        parts.append('type="fm"')
+        parts.append(f"sinedc={format_spectre_value(self.offset)}")
+        parts.append(f"ampl={format_spectre_value(self.amplitude)}")
+        parts.append(f"freq={format_spectre_value(self.carrier_frequency)}")
+        parts.append(f"modindex={format_spectre_value(self.modulation_index)}")
+        parts.append(f"modfreq={format_spectre_value(self.signal_frequency)}")
+        return ' '.join(parts)
 
 ####################################################################################################
 
@@ -846,6 +881,7 @@ class SingleFrequencyFMVoltageSource(VoltageSource, VoltageSourceMixinAbc, Singl
     ##############################################
 
     format_spice_parameters = SingleFrequencyFMMixin.format_spice_parameters
+    format_spectre_parameters = SingleFrequencyFMMixin.format_spectre_parameters
 
 ####################################################################################################
 
@@ -866,6 +902,7 @@ class SingleFrequencyFMCurrentSource(CurrentSource, CurrentSourceMixinAbc, Singl
     ##############################################
 
     format_spice_parameters = SingleFrequencyFMMixin.format_spice_parameters
+    format_spectre_parameters = SingleFrequencyFMMixin.format_spectre_parameters
 
 ####################################################################################################
 

--- a/InSpice/Unit/Unit.py
+++ b/InSpice/Unit/Unit.py
@@ -1459,11 +1459,14 @@ class UnitValues(np.ndarray):
 
         # Floating functions
         # --------------------------------------------------
-        np.isfinite:  CONVERSION.NOT_IMPLEMENTED,   # ! _T
-        np.isinf:     CONVERSION.NOT_IMPLEMENTED,   # ! _T
-        np.isnan:     CONVERSION.NOT_IMPLEMENTED,   # ! _T
+        # Unit-agnostic boolean predicates: operate on the raw values and return a
+        # bool array (units are irrelevant). matplotlib calls np.isnan() on plotted
+        # data, so these must pass through rather than raise NotImplementedError.
+        np.isfinite:  CONVERSION.FLOAT,
+        np.isinf:     CONVERSION.FLOAT,
+        np.isnan:     CONVERSION.FLOAT,
         np.fabs:      CONVERSION.NOT_IMPLEMENTED,   # ! _
-        np.signbit:   CONVERSION.NOT_IMPLEMENTED,   # ! _T
+        np.signbit:   CONVERSION.FLOAT,
         np.copysign:  CONVERSION.NOT_IMPLEMENTED,   # !
         np.nextafter: CONVERSION.NOT_IMPLEMENTED,   # !
         np.spacing:   CONVERSION.NOT_IMPLEMENTED,   # !

--- a/unit-test/Spice/test_SpectreFormat.py
+++ b/unit-test/Spice/test_SpectreFormat.py
@@ -212,6 +212,27 @@ class TestHighLevelElementSpectre(unittest.TestCase):
         self.assertIn('type="exp"', result)
         self.assertIn('val0=0', result)
         self.assertIn('val1=5', result)
+        # vacask td2 is the rise duration from delay: fall_delay - rise_delay = 1e-6
+        self.assertIn('delay=1e-06', result)
+        self.assertIn('tau1=1e-06', result)
+        self.assertIn('td2=1e-06', result)
+        self.assertIn('tau2=1e-06', result)
+        # the absolute SPICE TD2 (2e-6) must NOT leak through as td2
+        self.assertNotIn('td2=2e-06', result)
+
+    def test_pulse_voltage_source_zero_rise(self):
+        # rise_time defaults to 0; vacask rejects rise <= 0 so it must be omitted,
+        # letting vacask fall back to its 1n default.
+        circuit = Circuit('Test')
+        circuit.PulseVoltageSource('clk', 'clk', circuit.gnd,
+                                    initial_value=0, pulsed_value=5,
+                                    pulse_width=5@u_ms, period=10@u_ms,
+                                    fall_time=1@u_us)
+        element = circuit['Vclk']
+        ctx = SpectreContext()
+        result = element.to_spectre(ctx)
+        self.assertIn('type="pulse"', result)
+        self.assertNotIn('rise=', result)
 
     def test_pwl_voltage_source(self):
         circuit = Circuit('Test')
@@ -219,10 +240,37 @@ class TestHighLevelElementSpectre(unittest.TestCase):
                                              values=[(0, 0), (1e-3, 5)])
         element = circuit['Vpwl']
         ctx = SpectreContext()
+        # vacask has no Pwl compute branch, so PWL must fail loudly, not emit.
+        with self.assertRaises(NotImplementedError):
+            element.to_spectre(ctx)
+
+    def test_sffm_voltage_source(self):
+        circuit = Circuit('Test')
+        circuit.SingleFrequencyFMVoltageSource('fm', 'out', circuit.gnd,
+                                               offset=0, amplitude=1,
+                                               carrier_frequency=1@u_kHz,
+                                               modulation_index=5,
+                                               signal_frequency=100@u_Hz)
+        element = circuit['Vfm']
+        ctx = SpectreContext()
         result = element.to_spectre(ctx)
         self.assertIn('vsource', result)
-        self.assertIn('type="pwl"', result)
-        self.assertIn('wave=[', result)
+        self.assertIn('type="fm"', result)
+        self.assertIn('freq=1000', result)
+        self.assertIn('modfreq=100', result)
+        self.assertIn('modindex=5', result)
+
+    def test_generic_voltage_source_tran_raises(self):
+        # A generic VoltageSource carries a raw SPICE transient in tran_value, which
+        # has no Spectre translation and would be silently dropped (-> flat DC).
+        circuit = Circuit('Test')
+        circuit.V('sig', 'inp', circuit.gnd, dc_value=0, tran_value='SIN(0 1 1k)')
+        element = circuit['Vsig']
+        ctx = SpectreContext()
+        with self.assertRaises(NotImplementedError):
+            element.to_spectre(ctx)
+        # The ngspice path must still emit the transient verbatim.
+        self.assertIn('SIN(0 1 1k)', element.to_spice())
 
 ####################################################################################################
 

--- a/unit-test/Spice/test_Vacask.py
+++ b/unit-test/Spice/test_Vacask.py
@@ -434,15 +434,18 @@ class TestVacaskServerErrorHandling(unittest.TestCase):
 
 class TestSpectreUnsupportedSources(unittest.TestCase):
 
-    def test_sffm_spectre_not_supported(self):
-        """S9: SFFM sources must raise NotImplementedError for Spectre output."""
+    def test_sffm_spectre_supported(self):
+        """SFFM maps to vacask's native type="fm" waveform."""
         from InSpice.Spice.HighLevelElement import SingleFrequencyFMMixin, VoltageSourceMixinAbc
         class TestSFFM(VoltageSourceMixinAbc, SingleFrequencyFMMixin):
             pass
         src = TestSFFM(offset=0, amplitude=1, carrier_frequency=1e3,
                        modulation_index=5, signal_frequency=10)
-        with self.assertRaises(NotImplementedError):
-            src.format_spectre_parameters()
+        result = src.format_spectre_parameters()
+        self.assertIn('type="fm"', result)
+        self.assertIn('freq=1000', result)
+        self.assertIn('modfreq=10', result)
+        self.assertIn('modindex=5', result)
 
     def test_am_spectre_not_supported(self):
         """S9: AM sources must raise NotImplementedError for Spectre output."""


### PR DESCRIPTION
## Summary

Fixes and extends transient independent-source codegen for the **VACASK** (Spectre-dialect) target. Several waveforms previously emitted netlists that vacask rejects or computes incorrectly; the loose `assertIn` tests didn't catch it.

- **EXP**: fix `td2` semantics. vacask uses `t_fall_start = delay + td2` (i.e. `td2` is the rise *duration* from `delay`), whereas SPICE's `TD2` is absolute from t=0. Now maps `delay=rise_delay_time`, `td2=fall_delay_time-rise_delay_time`, `tau1/tau2` accordingly, and raises `ValueError` when `td2<=0` or `rise_time_constant`/`fall_delay_time` is missing (vacask requires `td2>0` and divides by `tau1`).
- **PULSE**: only emit `rise=` when `rise_time>0`. vacask rejects `rise<=0` and defaults to `1n` when omitted; InSpice defaulted `rise_time` to 0, which vacask rejected.
- **PWL**: raise `NotImplementedError` on the Spectre/VACASK path — vacask's `sourceCompute` has no `Pwl` branch, so `type="pwl"` would run but return an uninitialised value.
- **SFFM**: implement vacask `type="fm"` (exact formula match) and wire `format_spectre_parameters` into the FM voltage/current source classes.
- **Generic source**: `Element.to_spectre()` now raises instead of silently dropping a raw SPICE `tran_value` (which produced a flat `dc=0` source). Points users to the structural source classes. The ngspice path is unchanged.

No VACASK C++ changes. A future follow-up could add the `Pwl` compute branch, after which PWL emission can be restored.

## Test Plan

- [x] `pytest unit-test/Spice/test_SpectreFormat.py unit-test/Spice/test_Vacask.py` — green
- [x] Full `unit-test/Spice/` suite — 74 passed
- [x] End-to-end with `vacask-bin`: SIN/PULSE/EXP/SFFM drive an RC circuit through the real vacask binary with no setup/compute errors and sensible filtered outputs; PWL raises `NotImplementedError` at generation time.
