### PR TITLE
feat(vacask): add .include(), .lib(), and .parameter() directive support

### DIFF
--- a/InSpice/Spice/Netlist.py
+++ b/InSpice/Spice/Netlist.py
@@ -650,6 +650,8 @@ class Circuit(Netlist):
 
         for include in self._includes:
             circuit.include(include)
+        for name, section in self._libs:
+            circuit.lib(name, section)
         for name, value in self._parameters.items():
             circuit.parameter(name, value)
 

--- a/InSpice/Spice/Vacask/Simulation.py
+++ b/InSpice/Spice/Vacask/Simulation.py
@@ -27,6 +27,7 @@ VACASK uses Spectre-like syntax, not SPICE. This module translates InSpice Circu
 ####################################################################################################
 
 import logging
+from pathlib import Path
 
 ####################################################################################################
 
@@ -87,6 +88,21 @@ class VacaskSimulation(Simulation):
         lines.append('ground 0')
         lines.append('')
 
+        # Include directives
+        has_includes = False
+        for path in self._circuit._includes:
+            lines.append(f'include "{Path(path).resolve()}"')
+            has_includes = True
+        for lib_path, section in self._circuit._libs:
+            resolved = Path(str(lib_path)).resolve()
+            if section:
+                lines.append(f'include "{resolved}" section={section}')
+            else:
+                lines.append(f'include "{resolved}"')
+            has_includes = True
+        if has_includes:
+            lines.append('')
+
         # Collect OSDI files from default models too
         for prefix in context.default_models:
             if prefix in DEFAULT_MODELS:
@@ -113,9 +129,14 @@ class VacaskSimulation(Simulation):
             for line in model_lines:
                 lines.append(line)
 
+        # Parameters
+        if self._circuit._parameters:
+            params = ' '.join(f'{k}={v}' for k, v in self._circuit._parameters.items())
+            lines.append(f'parameters {params}')
+
         # Circuit body (subcircuits with models inside, explicit models, elements)
         if circuit_body:
-            if model_lines:
+            if model_lines or self._circuit._parameters:
                 lines.append('')
             for line in circuit_body.split('\n'):
                 lines.append(line)

--- a/unit-test/Spice/test_Vacask.py
+++ b/unit-test/Spice/test_Vacask.py
@@ -487,5 +487,104 @@ class TestNoiseSpectreOutput(unittest.TestCase):
 
 ####################################################################################################
 
+class TestVacaskIncludesAndLibs(unittest.TestCase):
+
+    def setUp(self):
+        self.simulator = Simulator.factory(simulator='vacask')
+
+    def _make_simulation(self, circuit):
+        return self.simulator.simulation(circuit)
+
+    ##############################################
+
+    def test_includes_in_spectre_output(self):
+        circuit = Circuit('Include Test')
+        circuit.include('/some/path/model.lib')
+        circuit.V('in', 'inp', circuit.gnd, 5)
+        circuit.R(1, 'inp', circuit.gnd, kilo(1))
+
+        simulation = self._make_simulation(circuit)
+        simulation.operating_point(run=False)
+        netlist = str(simulation)
+
+        self.assertIn('include "/some/path/model.lib"', netlist)
+
+    ##############################################
+
+    def test_libs_with_section_in_spectre_output(self):
+        circuit = Circuit('Lib Test')
+        circuit.lib('/pdk/models/corners.lib', 'tt')
+        circuit.V('in', 'inp', circuit.gnd, 5)
+        circuit.R(1, 'inp', circuit.gnd, kilo(1))
+
+        simulation = self._make_simulation(circuit)
+        simulation.operating_point(run=False)
+        netlist = str(simulation)
+
+        self.assertIn('include "/pdk/models/corners.lib" section=tt', netlist)
+
+    ##############################################
+
+    def test_lib_without_section(self):
+        circuit = Circuit('Lib No Section')
+        circuit.lib('/pdk/models/all.lib', None)
+        circuit.V('in', 'inp', circuit.gnd, 5)
+        circuit.R(1, 'inp', circuit.gnd, kilo(1))
+
+        simulation = self._make_simulation(circuit)
+        simulation.operating_point(run=False)
+        netlist = str(simulation)
+
+        self.assertIn('include "/pdk/models/all.lib"', netlist)
+        self.assertNotIn('section=', netlist)
+
+    ##############################################
+
+    def test_parameters_in_spectre_output(self):
+        circuit = Circuit('Param Test')
+        circuit.parameter('vdd', '1.8')
+        circuit.parameter('temp', '27')
+        circuit.V('in', 'inp', circuit.gnd, 5)
+        circuit.R(1, 'inp', circuit.gnd, kilo(1))
+
+        simulation = self._make_simulation(circuit)
+        simulation.operating_point(run=False)
+        netlist = str(simulation)
+
+        self.assertIn('parameters vdd=1.8 temp=27', netlist)
+
+    ##############################################
+
+    def test_includes_before_loads(self):
+        circuit = Circuit('Order Test')
+        circuit.include('/some/path/model.lib')
+        circuit.V('in', 'inp', circuit.gnd, 5)
+        circuit.R(1, 'inp', circuit.gnd, kilo(1))
+
+        simulation = self._make_simulation(circuit)
+        simulation.operating_point(run=False)
+        netlist = str(simulation)
+
+        include_pos = netlist.index('include "/some/path/model.lib"')
+        load_pos = netlist.index('load ')
+        self.assertLess(include_pos, load_pos)
+
+####################################################################################################
+
+class TestClonePreservesLibs(unittest.TestCase):
+
+    def test_clone_preserves_libs(self):
+        circuit = Circuit('Clone Lib Test')
+        circuit.lib('/pdk/corners.lib', 'tt')
+        circuit.lib('/pdk/models.lib', None)
+        circuit.V('in', 'inp', circuit.gnd, 5)
+        circuit.R(1, 'inp', circuit.gnd, kilo(1))
+
+        cloned = circuit.clone('Cloned')
+
+        self.assertEqual(list(cloned._libs), [('/pdk/corners.lib', 'tt'), ('/pdk/models.lib', None)])
+
+####################################################################################################
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- Add support for `.include()`, `.lib()`, and `.parameter()` directives in VACASK Spectre netlist output
- Add clone support for libs in Circuit
- Comprehensive tests for new directive functionality

## Test plan

- Run unit tests to verify new directive support works as expected